### PR TITLE
Fix bug in protection ability

### DIFF
--- a/macros/abilities.cfg
+++ b/macros/abilities.cfg
@@ -70,6 +70,10 @@ Any units adjacent to this unit will fight as if it were dusk when it is day, an
         name= _ "protection"
         description= _ "Adjacent units of lower level from this side receive a +20% bonus to all resistances (up to a maximum of 50%)."
         affect_self=no
+        [filter_base_value]
+        greater_than=0
+        less_than =50
+        [/filter_base_value]
         [affect_adjacent]
             [filter]
                 formula="level < other.level"

--- a/macros/abilities.cfg
+++ b/macros/abilities.cfg
@@ -71,7 +71,6 @@ Any units adjacent to this unit will fight as if it were dusk when it is day, an
         description= _ "Adjacent units of lower level from this side receive a +20% bonus to all resistances (up to a maximum of 50%)."
         affect_self=no
         [filter_base_value]
-        greater_than=0
         less_than =50
         [/filter_base_value]
         [affect_adjacent]


### PR DESCRIPTION
@shikadiqueen Protection ability convert 70% résistance to 50 because filter_base_value was not implemented like in steadfast for exclude resistances greater than max_value.